### PR TITLE
Ensure None values don't get included in the images

### DIFF
--- a/mopidy_youtube/backend.py
+++ b/mopidy_youtube/backend.py
@@ -66,13 +66,19 @@ def resolve_url(url, stream=False):
         logger.info(e.message)
         return
 
+    images = []
+    if video.bigthumb:
+        images.append(video.bigthumb)
+    if video.bigthumbhd:
+        images.append(video.bigthumbhd)
+
     track = Track(
         name=video.title,
         comment=video.videoid,
         length=video.length * 1000,
         album=Album(
             name='YouTube',
-            images=[video.bigthumb, video.bigthumbhd]
+            images=images
         ),
         uri=uri
     )

--- a/mopidy_youtube/backend.py
+++ b/mopidy_youtube/backend.py
@@ -67,9 +67,9 @@ def resolve_url(url, stream=False):
         return
 
     images = []
-    if video.bigthumb:
+    if video.bigthumb is not None:
         images.append(video.bigthumb)
-    if video.bigthumbhd:
+    if video.bigthumbhd is not None:
         images.append(video.bigthumbhd)
 
     track = Track(


### PR DESCRIPTION
An error occurs when the `bigthumbhd` property cannot be found on the video object (https://github.com/mopidy/mopidy-youtube/blob/861a71141491d0eb3a54731a71857eb5ed78a0a2/mopidy_youtube/backend.py#L75)

This should fixes the problem for me.