### PR TITLE
Quickfix: YouTube-API key invalid

### DIFF
--- a/mopidy_youtube/__init__.py
+++ b/mopidy_youtube/__init__.py
@@ -6,7 +6,7 @@ import os
 from mopidy import config, ext
 
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy_youtube/backend.py
+++ b/mopidy_youtube/backend.py
@@ -20,7 +20,7 @@ import requests
 from mopidy_youtube import logger
 
 yt_api_endpoint = 'https://www.googleapis.com/youtube/v3/'
-yt_key = 'AIzaSyAl1Xq9DwdE_KD4AtPaE4EJl3WZe2zCqg4'
+yt_key = 'AIzaSyAlwpbCQ6M_9v3kumk_uC1odreeBI0CAsw'
 session = requests.Session()
 
 video_uri_prefix = 'youtube:video'


### PR DESCRIPTION
Hi,

i just updated the API key to allow the extension to resolve playlists and do searches on YouTube.

Please note that those operations are very slow (1:30 to 3:00 minutes for a 17-video playlist). I'm currently working on a rewrite of the plugin to make those requests faster (or asynchronous).